### PR TITLE
##nuxt-lazytube

### DIFF
--- a/src/runtime/utils.js
+++ b/src/runtime/utils.js
@@ -15,6 +15,7 @@ const createIframe = (videoID, urlCompare, getTitle, iframeClass, iframePolicy, 
         if (type === 'youtube') {
             const mergedUrl = mergeQueryParams(`https://www.youtube.com/embed/${videoID}?enablejsapi=1&autoplay=1`, urlCompare);
             iframeEl.setAttribute('src', mergedUrl)
+            iframeEl.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin')
 
         } else {
             iframeEl.setAttribute('src', `https://player.vimeo.com/video/${videoID}?autoplay=1`)


### PR DESCRIPTION
You can remove the warning because Chrome now accepts the security policy the same way YouTube officially defines it.

In practice, this does two things:

Aligns your iframe with YouTube’s standard policy (which Chrome recognizes as safe).

Prevents conflicts with the browser’s internal Permissions Policies — especially when the video tries to use features like autoplay, fullscreen, or picture-in-picture.

Summary:
The referrerpolicy attribute controls how the browser handles cross-origin requests.
By setting it correctly, Chrome recognizes the iframe as “secure” and stops showing permission policy warnings.
This is the same attribute used in YouTube’s official embed code.