### PR TITLE
feat: set up automatic release workflow with changelog generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm install -g changelogen@latest
 
       - name: 📝 Gerar CHANGELOG.md
-        run: changelogen
+        run: changelogen --output CHANGELOG.md --release ${{ github.ref_name }}
 
       - name: 📄 Verificar se CHANGELOG.md existe
         run: |

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "nuxt": "4.2.0",
-    "nuxt-lazytube": "^0.2.4",
+    "nuxt-lazytube": "^0.2.5",
     "vue": "latest",
     "vue-router": "latest"
   }


### PR DESCRIPTION
Adds a GitHub Actions pipeline that generates the CHANGELOG.md using changelogen and automatically creates releases when new version tags (v*) are pushed. Includes GH_PAT token usage and integration with softprops/action-gh-release.