### PR TITLE
fix(preview): remove debug onceLoaded text

### DIFF
--- a/src/runtime/common/Preview.vue
+++ b/src/runtime/common/Preview.vue
@@ -72,7 +72,6 @@ const defaultThumbnail = computed(() => {
 
 <template>
   <div class="vlt-preview" @click="$emit('click')">
-    {{ onceLoaded }}
     <template v-if="!onceLoaded">
       <template v-if="isVideoFound ">
         <img v-if="isCustomThumbnailExist" :src="customThumbnail" :alt="'Video - ' + videoTitle"


### PR DESCRIPTION
In Preview.vue, a leftover debug message was still rendering `{{ onceLoaded }}` in the UI.

This PR removes that debug output, so the title no longer shifts and a random "true" is no longer shown to users.