### PR TITLE
fix(preview): hide preview overlay once loaded

### DIFF
--- a/src/runtime/common/Preview.vue
+++ b/src/runtime/common/Preview.vue
@@ -71,7 +71,7 @@ const defaultThumbnail = computed(() => {
 </script>
 
 <template>
-  <div class="vlt-preview" @click="$emit('click')">
+  <div :class="onceLoaded ? 'vlt-preview__hidden' : 'vlt-preview'" @click="$emit('click')">
     {{ onceLoaded }}
     <template v-if="!onceLoaded">
       <template v-if="isVideoFound ">


### PR DESCRIPTION
The preview overlay remained visible even after the video was loaded.

An unused `vlt-preview__hidden` class already existed, so this change uses it to toggle the preview between the visible and hidden state once loading is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview component visibility to properly toggle between shown and hidden states based on content loading completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->