### PR TITLE
fix(core): Remove nuxt-og-image module from docs

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
 
   css: ['~/assets/css/main.css'],
 
-  modules: ['@nuxt/image', '@nuxt/ui', '@nuxt/content', 'nuxt-og-image', 'nuxt-llms', 'nuxt-lazytube'],
+  modules: ['@nuxt/image', '@nuxt/ui', '@nuxt/content', 'nuxt-llms', 'nuxt-lazytube'],
 
   compatibilityDate: '2024-07-11',
 


### PR DESCRIPTION
Removes 'nuxt-og-image' from the modules array in docs/nuxt.config.ts.